### PR TITLE
Fix bug in squared_l2_norm

### DIFF
--- a/utils/adv_utils.py
+++ b/utils/adv_utils.py
@@ -5,7 +5,8 @@ from torch.autograd import Variable
 
 
 def squared_l2_norm(x):
-    flattened = x.view(x.unsqueeze(0).shape[0], -1)
+    """Compute the squared L2 norm for each sample in a batch."""
+    flattened = x.view(x.size(0), -1)
     return (flattened ** 2).sum(1)
 
 


### PR DESCRIPTION
## Summary
- correct the dimension handling when computing per-sample L2 norms

## Testing
- `python -m py_compile utils/adv_utils.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68409a25ee008320897c020e8ba149fc