### PR TITLE
Add PyTorch Lightning and multi-node training script

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,17 @@ To evaluate a VGG-16 model with a ratio of 0.5 using AutoAttack on CIFAR-10.
 ```
 python3 auto_attack_eval.py --arch vgg16_bn_ori --ratio 0.5 --source-net SOME_PATH
 ```
+### Distributed training
+
+We provide `train_lightning.py` for multi-GPU and multi-node training using PyTorch Lightning. An example Slurm script `slurm_pl_multinode.sh` runs training on two nodes with four GPUs each.
+
+To train a ResNet-50 MoE model on ImageNet with two nodes:
+
+```bash
+srun python3 train_lightning.py --arch resnet50_imagenet_moe --dataset ImageNet \
+    --normalize --batch-size 256 --gpus 4 --num-nodes 2
+```
+
 
 
 ## Dataset Preparation

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ datasets
 six
 tqdm
 scipy==1.6.0
+pytorch-lightning

--- a/slurm_pl_multinode.sh
+++ b/slurm_pl_multinode.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+#SBATCH --job-name=pl_train
+#SBATCH --nodes=2
+#SBATCH --ntasks-per-node=4
+#SBATCH --gpus-per-node=4
+#SBATCH --cpus-per-task=4
+#SBATCH --time=24:00:00
+#SBATCH --output=pl_train_%j.log
+
+# Activate your environment if needed
+# source ~/env/bin/activate
+
+srun python3 train_lightning.py \
+    --arch resnet50_imagenet_moe \
+    --dataset ImageNet \
+    --normalize \
+    --batch-size 256 \
+    --gpus 4 --num-nodes 2

--- a/train_lightning.py
+++ b/train_lightning.py
@@ -1,0 +1,82 @@
+import pytorch_lightning as pl
+import torch
+import torch.nn.functional as F
+
+from args import get_args_parser
+from utils.general_utils import prepare_data, initialize_weights, split_data_and_move_to_device
+import models
+from utils.schedules import get_optimizer
+
+
+class LightningClassifier(pl.LightningModule):
+    def __init__(self, args):
+        super().__init__()
+        self.save_hyperparameters(args)
+        # prepare data to know num_classes and normalization
+        train_loader, _, test_loader, normalize, num_classes, _ = prepare_data(args)
+        self.train_loader = train_loader
+        self.val_loader = test_loader
+        self.model = models.__dict__[args.arch](num_classes=num_classes,
+                                                n_expert=args.n_expert,
+                                                ratio=args.ratio)
+        initialize_weights(self.model)
+        if args.normalize:
+            self.model.normalize = normalize
+
+    def forward(self, x):
+        return self.model(x)
+
+    def training_step(self, batch, batch_idx):
+        images, target = split_data_and_move_to_device(batch, self.device)
+        output = self(images)
+        loss = F.cross_entropy(output, target)
+        acc = (output.argmax(dim=1) == target).float().mean()
+        self.log("train_loss", loss, on_step=True, prog_bar=True)
+        self.log("train_acc", acc, on_step=True, prog_bar=True)
+        return loss
+
+    def validation_step(self, batch, batch_idx):
+        images, target = split_data_and_move_to_device(batch, self.device)
+        output = self(images)
+        loss = F.cross_entropy(output, target)
+        acc = (output.argmax(dim=1) == target).float().mean()
+        self.log("val_loss", loss, prog_bar=True)
+        self.log("val_acc", acc, prog_bar=True)
+
+    def configure_optimizers(self):
+        optimizer = get_optimizer(self.model, self.hparams)
+        return optimizer
+
+    def train_dataloader(self):
+        return self.train_loader
+
+    def val_dataloader(self):
+        return self.val_loader
+
+
+def main():
+    parser = get_args_parser()
+    parser.set_defaults(
+        arch="resnet50_imagenet_moe",
+        dataset="ImageNet",
+        batch_size=256,
+        normalize=True,
+    )
+    parser.add_argument('--gpus', type=int, default=1, help='number of gpus per node')
+    parser.add_argument('--num-nodes', type=int, default=1, help='number of nodes for training')
+    args = parser.parse_args()
+
+    model = LightningClassifier(args)
+
+    trainer = pl.Trainer(
+        max_epochs=args.epochs,
+        accelerator='gpu' if torch.cuda.is_available() else 'cpu',
+        devices=args.gpus if torch.cuda.is_available() else None,
+        num_nodes=args.num_nodes,
+        strategy='ddp' if args.gpus > 1 or args.num_nodes > 1 else None,
+    )
+    trainer.fit(model)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add new `train_lightning.py` for PyTorch Lightning based training
- include example Slurm script for 2 nodes x 4 GPUs
- document distributed training in README
- include `pytorch-lightning` in requirements
- set defaults for ResNet-50 MoE ImageNet run

## Testing
- `python3 -m py_compile train_lightning.py`


------
https://chatgpt.com/codex/tasks/task_e_6840d75e6000832082e0324716ac4a06